### PR TITLE
feat: Improve credit card advance functionality

### DIFF
--- a/client/src/context/CreditCardContext.tsx
+++ b/client/src/context/CreditCardContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useState, useEffect } from 'react';
 import { CreditCard, CreditCardAdvance } from '../types';
 import { supabase } from '../lib/supabase';
 import { useAuth } from './AuthContext';
+import { useFinance } from './FinanceContext';
 
 interface CreditCardContextType {
   creditCards: CreditCard[];
@@ -31,6 +32,7 @@ export const CreditCardProvider: React.FC<{ children: React.ReactNode }> = ({ ch
   const [creditCardAdvances, setCreditCardAdvances] = useState<CreditCardAdvance[]>([]);
   const [loading, setLoading] = useState(true);
   const { currentUser: user } = useAuth();
+  const { addExpense, deleteExpense: deleteExpenseFromFinance } = useFinance();
 
   const loadCreditCards = async () => {
     if (!user) return;
@@ -360,19 +362,26 @@ export const CreditCardProvider: React.FC<{ children: React.ReactNode }> = ({ ch
           const invoiceDate = representativeCard?.date || new Date(parseInt(year), parseInt(month), 0).toISOString().split('T')[0];
 
           if (existingInvoices && existingInvoices.length > 0) {
-            // Update existing invoice with new format
-            const { error: updateError } = await supabase
-              .from('expenses')
-              .update({
-                amount: finalTotal,
-                date: invoiceDate,
-                payment_method: invoicePaymentMethod,
-                description: invoiceDescription, // Update to new format
-              })
-              .eq('id', existingInvoices[0].id);
+            const existingInvoiceId = existingInvoices[0].id;
+            if (finalTotal <= 0) {
+              // If the final total is zero or less, delete the invoice expense
+              await deleteExpenseFromFinance(existingInvoiceId);
+              console.log(`✅ Deleted invoice with zero balance: ${invoiceDescription}`);
+            } else {
+              // Otherwise, update the existing invoice
+              const { error: updateError } = await supabase
+                .from('expenses')
+                .update({
+                  amount: finalTotal,
+                  date: invoiceDate,
+                  payment_method: invoicePaymentMethod,
+                  description: invoiceDescription, // Update to new format
+                })
+                .eq('id', existingInvoiceId);
 
-            if (!updateError) {
-              console.log(`✅ Updated: ${invoiceDescription} - R$ ${finalTotal.toFixed(2)}`);
+              if (!updateError) {
+                console.log(`✅ Updated: ${invoiceDescription} - R$ ${finalTotal.toFixed(2)}`);
+              }
             }
           } else if (finalTotal > 0) {
             // Create new invoice only if there's a positive balance
@@ -428,13 +437,40 @@ export const CreditCardProvider: React.FC<{ children: React.ReactNode }> = ({ ch
         throw error;
       }
 
+      const expenseForAdvance = {
+        date: advanceData.date,
+        category: 'Adiantamento',
+        description: `Adiantamento de Fatura ${advanceData.payment_method}`,
+        amount: advanceData.amount,
+        paymentMethod: advanceData.payment_method,
+        paid: true,
+        isCreditCard: false,
+      };
+
+      // Add the expense and get the created record
+      const newExpense = await addExpense(expenseForAdvance);
+
+      const { data: insertedAdvance, error: insertAdvanceError } = await supabase
+        .from('credit_card_advances')
+        .insert([{ ...advanceData, user_id: user.id, expense_id: newExpense.id }])
+        .select()
+        .single();
+
+      if (insertAdvanceError) {
+        console.error("Context: Supabase insert error:", insertAdvanceError);
+        // Rollback the expense creation
+        await deleteExpenseFromFinance(newExpense.id);
+        throw insertAdvanceError;
+      }
+
       const newAdvance: CreditCardAdvance = {
-        id: data.id,
-        user_id: data.user_id,
-        payment_method: data.payment_method,
-        amount: parseFloat(data.amount),
-        date: data.date,
-        remaining_amount: parseFloat(data.remaining_amount),
+        id: insertedAdvance.id,
+        user_id: insertedAdvance.user_id,
+        payment_method: insertedAdvance.payment_method,
+        amount: parseFloat(insertedAdvance.amount),
+        date: insertedAdvance.date,
+        remaining_amount: parseFloat(insertedAdvance.remaining_amount),
+        expense_id: insertedAdvance.expense_id,
       };
 
       const newAdvances = [newAdvance, ...creditCardAdvances];
@@ -493,6 +529,7 @@ export const CreditCardProvider: React.FC<{ children: React.ReactNode }> = ({ ch
     }
 
     try {
+      // First, delete the advance from the database
       const { error } = await supabase
         .from('credit_card_advances')
         .delete()
@@ -501,6 +538,11 @@ export const CreditCardProvider: React.FC<{ children: React.ReactNode }> = ({ ch
 
       if (error) {
         throw error;
+      }
+
+      // If the advance had a linked expense, delete it
+      if (advanceToDelete.expense_id) {
+        await deleteExpenseFromFinance(advanceToDelete.expense_id);
       }
 
       const newAdvances = creditCardAdvances.filter(adv => adv.id !== id);

--- a/client/src/context/FinanceContext.tsx
+++ b/client/src/context/FinanceContext.tsx
@@ -14,7 +14,7 @@ interface FinanceContextType {
   categories: Category[];
   transfers: Transfer[];
   filters: FilterState;
-  addExpense: (expense: Omit<Expense, 'id' | 'createdAt'>) => void;
+  addExpense: (expense: Omit<Expense, 'id' | 'createdAt'>) => Promise<Expense>;
   addIncome: (income: Omit<Income, 'id' | 'createdAt'>) => void;
   addCategory: (category: Omit<Category, 'id' | 'createdAt'>) => void;
   addTransfer: (transfer: Omit<Transfer, 'id' | 'createdAt' | 'userId'>) => void;
@@ -507,7 +507,7 @@ export const FinanceProvider: React.FC<FinanceProviderProps> = ({ children }) =>
     };
   }, [currentUserId, dataLoadingDisabled]); // Include dataLoadingDisabled in dependencies
 
-  const addExpense = async (expense: Omit<Expense, 'id' | 'createdAt'>) => {
+  const addExpense = async (expense: Omit<Expense, 'id' | 'createdAt'>): Promise<Expense> => {
     if (!currentUser) {
       console.error('❌ User not authenticated');
       throw new Error('User not authenticated');
@@ -578,6 +578,7 @@ export const FinanceProvider: React.FC<FinanceProviderProps> = ({ children }) =>
 
       setExpenses(prev => prev.map(exp => exp.id === tempId ? confirmedExpense : exp));
       console.log('✅ Expense synced successfully:', confirmedExpense.id);
+      return confirmedExpense;
     } catch (error) {
       console.error('❌ Error adding expense:', error);
       throw error;

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -22,6 +22,16 @@ export interface Expense {
   groupEndDate?: string;
 }
 
+export interface CreditCardAdvance {
+  id: string;
+  user_id: string;
+  payment_method: string;
+  amount: number;
+  date: string;
+  remaining_amount: number;
+  expense_id?: string;
+}
+
 export interface CreditCard {
   id: string;
   date: string; // Stored in YYYY-MM-DD format

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -139,6 +139,7 @@ export interface CreditCardAdvance {
   amount: number;
   date: string;
   remaining_amount: number;
+  expense_id?: string;
 }
 
 export type InsertCreditCardAdvance = Omit<CreditCardAdvance, 'id'>;
@@ -149,4 +150,5 @@ export const insertCreditCardAdvanceSchema = z.object({
   amount: z.number(),
   date: z.string(),
   remaining_amount: z.number(),
+  expense_id: z.string().optional(),
 });

--- a/supabase/migrations/20250917165700_add_expense_id_to_credit_card_advances.sql
+++ b/supabase/migrations/20250917165700_add_expense_id_to_credit_card_advances.sql
@@ -1,0 +1,23 @@
+-- Add expense_id to credit_card_advances and link it to expenses
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'credit_card_advances' AND column_name = 'expense_id'
+  ) THEN
+    ALTER TABLE public.credit_card_advances
+    ADD COLUMN expense_id UUID;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'credit_card_advances_expense_id_fkey'
+  ) THEN
+    ALTER TABLE public.credit_card_advances
+    ADD CONSTRAINT credit_card_advances_expense_id_fkey
+    FOREIGN KEY (expense_id) REFERENCES public.expenses(id) ON DELETE SET NULL;
+  END IF;
+END $$;


### PR DESCRIPTION
This commit improves the credit card advance feature by integrating it with the expenses module and refining the invoice settlement logic.

Key changes:
- When a credit card advance is created, a corresponding expense is now automatically generated with the description "Adiantamento de Fatura".
- A foreign key `expense_id` has been added to the `credit_card_advances` table to link advances to their corresponding expenses.
- Deleting a credit card advance now also deletes the associated expense.
- The invoice generation logic has been updated. If an invoice's balance is zero or less after applying advances, the invoice's expense record is now deleted from the expenses list.
- The `addExpense` function in `FinanceContext` now returns the newly created expense object, making it easier to link expenses to other records.