### PR TITLE
fix: Resolve UI bugs in credit card advance form

### DIFF
--- a/client/src/components/CreditCardAdvanceForm.tsx
+++ b/client/src/components/CreditCardAdvanceForm.tsx
@@ -141,10 +141,20 @@ export function CreditCardAdvanceForm({ isOpen, onClose }: CreditCardAdvanceForm
                 Valor <span className="text-red-500">*</span>
               </label>
               <input
-                type="number"
-                step="0.01"
+                type="text"
                 placeholder="0,00"
-                {...register('amount', { valueAsNumber: true })}
+                value={watch('amount').toString().replace('.', ',')}
+                onChange={(e) => {
+                  const value = e.target.value;
+                  const cleaned = value.replace(/[^\d,]/g, '');
+                  const parts = cleaned.split(',');
+                  if (parts.length > 2) return;
+                  if (parts[1] && parts[1].length > 2) {
+                    parts[1] = parts[1].substring(0, 2);
+                  }
+                  const formatted = parts.join(',');
+                  setValue('amount', parseFloat(formatted.replace(',', '.')) || 0, { shouldValidate: true });
+                }}
                 className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
               />
               {errors.amount && <p className="text-sm text-red-500 mt-1">{errors.amount.message}</p>}

--- a/client/src/context/CreditCardContext.tsx
+++ b/client/src/context/CreditCardContext.tsx
@@ -450,8 +450,12 @@ export const CreditCardProvider: React.FC<{ children: React.ReactNode }> = ({ ch
         expense_id: insertedAdvance.expense_id,
       };
 
-      const newAdvances = [newAdvance, ...creditCardAdvances];
-      setCreditCardAdvances(newAdvances);
+      setCreditCardAdvances(prev => {
+        if (prev.some(adv => adv.id === newAdvance.id)) {
+          return prev;
+        }
+        return [newAdvance, ...prev];
+      });
       console.log('Context: ✅ Credit card advance added to state');
 
       console.log("Context: Calling syncAllInvoicesToExpenses after adding advance...");


### PR DESCRIPTION
This commit fixes two UI-related issues in the credit card advance form:

1.  **Duplicate Entries:** After adding an advance, it would sometimes appear duplicated in the list. This was caused by a race condition between the optimistic UI update and a data reload. The state update logic in `CreditCardContext` has been made idempotent to prevent adding an advance if it already exists in the state.

2.  **Incorrect Amount Format:** The amount input field did not support comma-based decimal formatting. The input has been changed to a controlled component with logic to correctly handle and display currency values in the Brazilian format, consistent with other forms in the application.