### PR TITLE
fix: Remove duplicate variable declaration to fix build

### DIFF
--- a/client/src/context/CreditCardContext.tsx
+++ b/client/src/context/CreditCardContext.tsx
@@ -315,7 +315,6 @@ export const CreditCardProvider: React.FC<{ children: React.ReactNode }> = ({ ch
         const monthName = monthNames[parseInt(month) - 1];
         
         const trimmedPaymentMethod = paymentMethod.trim();
-        const monthName = monthNames[parseInt(month) - 1];
 
         // This is the new canonical format requested by the user.
         const desc_canonical_user_format = `Fatura ${trimmedPaymentMethod} - ${monthName}/${year}`;


### PR DESCRIPTION
This commit provides a definitive fix for the Netlify build failure caused by a duplicate declaration of the `monthName` constant in `CreditCardContext.tsx`.

This error was inadvertently re-introduced during previous fixes. This commit removes the duplicate line to ensure the application can build and deploy successfully.