### PR TITLE
fix: Simplify build script to debug deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
-    "build": "vite build --config vite.config.ts && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "vite build --config vite.config.ts",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push"


### PR DESCRIPTION
This commit simplifies the build script in `package.json` to only run the Vite build. This is a debugging step to isolate a potential issue in the deployment pipeline.

The previous build command included an `esbuild` command for the server, which is not necessary for deploying the frontend. By removing it, we can determine if the Vite build process itself is the source of the deployment problem.