### PR TITLE
fix: Add defensive checks to prevent AI chat crash

### DIFF
--- a/client/src/components/FinancialAIChat.tsx
+++ b/client/src/components/FinancialAIChat.tsx
@@ -31,7 +31,11 @@ const FinancialAIChat: React.FC = () => {
 
   // Generate financial context for AI
   const financialContext = useMemo(() => {
-    if (!expenses.length && !income.length) return null;
+    // Add robust checks to ensure all data arrays are defined
+    if (!expenses || !income || !transfers || !accounts) {
+      return null;
+    }
+    if (expenses.length === 0 && income.length === 0) return null;
 
     const today = new Date();
     const startOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);


### PR DESCRIPTION
This hotfix addresses a critical crash in the Financial AI chat modal. The crash was caused by a race condition where the chat component would attempt to process data from contexts (`expenses`, `income`, etc.) before they were fully initialized, leading to a `TypeError: Cannot read properties of undefined (reading 'length')`.

The fix implements a robust defensive check at the beginning of the `useMemo` hook in `FinancialAIChat.tsx` to ensure all required data arrays are defined before any processing occurs. This prevents the crash and makes the component more stable.