### PR TITLE
fix: Remove dead code to prevent AI chat crash

### DIFF
--- a/client/src/components/FinancialAIChat.tsx
+++ b/client/src/components/FinancialAIChat.tsx
@@ -245,49 +245,12 @@ Responda de forma clara e útil baseando-se nos dados reais fornecidos:`;
     }
   };
 
-  const handleQuickQuestion = (question: string) => {
-    setInput(question);
-  };
-
   const handleClearHistory = () => {
     if (window.confirm('Tem certeza que deseja limpar todo o histórico de conversas?')) {
       clearHistory();
       showSuccess('Histórico limpo', 'O histórico de conversas foi removido com sucesso.');
     }
   };
-
-  const quickQuestions = useMemo(() => {
-    if (!financialContext) {
-      return [
-        'Como organizar minhas finanças?',
-        'Dicas para economizar dinheiro',
-        'Como criar um orçamento mensal?',
-        'Estratégias de investimento básicas'
-      ];
-    }
-
-    const questions = [
-      'Analise meus gastos deste mês',
-      'Onde posso economizar mais?',
-      'Qual categoria gasto demais?',
-      'Como está meu saldo atual?'
-    ];
-
-    // Add specific questions based on data
-    if (parseFloat(financialContext.summary.creditCardTotal) > 0) {
-      questions.push('Analise meus gastos no cartão de crédito');
-    }
-
-    if (parseFloat(financialContext.summary.monthlyBalance) < 0) {
-      questions.push('Como equilibrar minhas finanças?');
-    }
-
-    if (financialContext.topCategories.length > 0) {
-      questions.push(`Dicas para reduzir gastos em ${financialContext.topCategories[0].category}`);
-    }
-
-    return questions.slice(0, 6);
-  }, [financialContext]);
 
   return (
     <div className="flex flex-col h-full">


### PR DESCRIPTION
This hotfix addresses a persistent crash in the Financial AI chat modal. The root cause was dead code related to a removed 'Quick Questions' feature. A `useMemo` hook that calculated these questions was still present and attempting to access properties on a data object (`financialContext`) that had been refactored, leading to a `TypeError`.

This commit completely removes the unused `quickQuestions` `useMemo` hook and its related functions, definitively resolving the crash.