### PR TITLE
Fix(dashboard): Correctly calculate monthly totals

### DIFF
--- a/client/src/components/Dashboard.tsx
+++ b/client/src/components/Dashboard.tsx
@@ -89,13 +89,24 @@ const Dashboard: React.FC = () => {
       .reduce((sum, inc) => sum + inc.amount, 0);
 
     // Gastos do Mês: Soma de todos os lançamentos em 'expenses' para o mês.
-    const totalMonthlySpending = expenses
+    const totalMonthlyDirectSpending = expenses
       .filter(exp => {
         const expenseDate = new Date(exp.date);
         return expenseDate.getMonth() === currentMonth && 
                expenseDate.getFullYear() === currentYear;
       })
       .reduce((sum, exp) => sum + exp.amount, 0);
+
+    // Gastos com Cartão de Crédito no Mês
+    const monthlyCreditCardSpending = creditCards
+      .filter(card => {
+        const cardDate = new Date(card.date);
+        return cardDate.getMonth() === currentMonth &&
+               cardDate.getFullYear() === currentYear;
+      })
+      .reduce((sum, card) => sum + card.amount, 0);
+
+    const totalMonthlySpending = totalMonthlyDirectSpending + monthlyCreditCardSpending;
 
     // Resultado do Mês: Receitas - Despesas
     const monthlyResult = monthlyIncome - totalMonthlySpending;
@@ -106,7 +117,7 @@ const Dashboard: React.FC = () => {
       totalMonthlySpending,
       monthlyResult
     };
-  }, [accounts, income, expenses, currentMonth, currentYear]);
+  }, [accounts, income, expenses, creditCards, currentMonth, currentYear]);
 
   // 2. SEÇÃO: Cartões de Crédito
   const creditCardAnalysis = useMemo(() => {


### PR DESCRIPTION
The dashboard cards for total expenses and total income were not correctly calculating the totals for the selected month.

This commit fixes the issue by:
- Updating the 'Gastos do Mês' (Monthly Expenses) calculation to include both direct expenses and credit card transactions for the selected month.
- Ensuring the 'Receitas do Mês' (Monthly Income) calculation correctly filters by the selected month.