### PR TITLE
Fix(dashboard): Correct all date and credit card calculations

### DIFF
--- a/client/src/components/Dashboard.tsx
+++ b/client/src/components/Dashboard.tsx
@@ -112,8 +112,8 @@ const Dashboard: React.FC = () => {
   const creditCardAnalysis = useMemo(() => {
     const allInvoices = creditCards.reduce((acc, card) => {
       const transactionDate = new Date(`${card.date}T00:00:00`);
-      // Assumindo que a fatura vence no mês seguinte à transação
-      const invoiceDate = new Date(transactionDate.getFullYear(), transactionDate.getMonth() + 1, 1);
+      // A fatura agrupa transações que ocorreram no mesmo mês.
+      const invoiceDate = new Date(transactionDate.getFullYear(), transactionDate.getMonth(), 1);
       const monthKey = `${invoiceDate.getFullYear()}-${invoiceDate.getMonth()}`;
 
       if (!acc[monthKey]) {
@@ -148,11 +148,20 @@ const Dashboard: React.FC = () => {
     // Maior Fatura: De todas as faturas existentes.
     const largestInvoice = Object.values(allInvoices).reduce((max, inv) => {
       if (inv.total > max.amount) {
-        // Encontra o cartão com o maior gasto nessa fatura
-        const largestCardInInvoice = Object.entries(inv.cards).sort(([, a], [, b]) => b - a)[0];
+        const sortedCards = Object.entries(inv.cards).sort(([, a], [, b]) => b - a);
+        let cardName = 'Nenhum'; // Default if no cards
+        if (sortedCards.length > 0) {
+            const firstValidCard = sortedCards.find(([name]) => name !== 'Desconhecido');
+            if (firstValidCard) {
+                cardName = firstValidCard[0];
+            } else {
+                cardName = 'Múltiplos Cartões'; // Fallback if all are unknown
+            }
+        }
+
         return {
           amount: inv.total,
-          card: largestCardInInvoice ? largestCardInInvoice[0] : 'Múltiplos',
+          card: cardName,
           month: inv.month,
           year: inv.year
         };


### PR DESCRIPTION
This commit addresses several issues on the dashboard to ensure all displayed values are correct and consistent with other parts of the application.

- **Date Parsing:** All date comparisons now correctly handle timezones by parsing date strings as local time (e.g., `new Date(`${date}T00:00:00`)`). This fixes the primary bug where monthly totals for income and expenses were incorrect.

- **Credit Card Invoices:** The logic for grouping credit card transactions into invoices has been corrected to group by calendar month, matching the behavior of the "Cartão" tab. This fixes inconsistencies in the "Próxima Fatura" and "Maior Fatura" cards.

- **Maior Fatura Display:** The logic for the "Maior Fatura" card has been improved to show a more user-friendly name ("Múltiplos Cartões") when the underlying data for the card name is missing.

- **UI Clarity:** The subtitle for the "Gastos do Mês" card has been changed to "Despesas" to accurately reflect its content.