### PR TITLE
feat(reconciliation): Add detection for transactions missing from sta…

### DIFF
--- a/client/src/components/CreditCardList.tsx
+++ b/client/src/components/CreditCardList.tsx
@@ -674,6 +674,7 @@ const CreditCardList: React.FC = () => {
           reconAccount={reconciliationData.reconAccount}
           parsedTransactions={reconciliationData.parsedTransactions}
           onAddExpense={handleAddCardFromReconciliation}
+          onDeleteExpense={deleteCreditCard}
         />
       )}
       <ConfirmDialog

--- a/client/src/components/ReconciliationResults.tsx
+++ b/client/src/components/ReconciliationResults.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useEffect, useMemo } from 'react';
-import { X, Plus, CheckCircle2, AlertCircle, Eye, EyeOff } from 'lucide-react';
+import React, { useMemo, useState } from 'react';
+import { X, AlertTriangle, CheckCircle, PlusCircle, Trash2, Plus, Eye, EyeOff } from 'lucide-react';
 import type { CreditCard } from '../types/index';
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
 
-// This is the structured transaction object we get from the first modal
 interface StatementTransaction {
   date: string;
   description: string;
@@ -10,23 +11,15 @@ interface StatementTransaction {
   raw: string;
 }
 
-// This is an augmented transaction object that includes the reconciliation status
-interface ReconciledTransaction extends StatementTransaction {
-  isMatched: boolean;
-}
-
 interface ReconciliationResultsProps {
   isOpen: boolean;
   onClose: () => void;
-  // The full list of transactions from the app
   creditCards: CreditCard[];
-  // The month and account selected in the first modal
   reconMonth: string;
   reconAccount: string;
-  // The transactions parsed from the statement in the first modal
   parsedTransactions: StatementTransaction[];
-  // The handler to trigger adding a new expense
-  onAddExpense: (cardData: Partial<CreditCard>) => void;
+  onAddExpense: (expense: Partial<CreditCard>) => void;
+  onDeleteExpense?: (expenseId: string) => void;
 }
 
 const ReconciliationResults: React.FC<ReconciliationResultsProps> = ({
@@ -37,136 +30,147 @@ const ReconciliationResults: React.FC<ReconciliationResultsProps> = ({
   reconAccount,
   parsedTransactions,
   onAddExpense,
+  onDeleteExpense,
 }) => {
-  const [reconciledTransactions, setReconciledTransactions] = useState<ReconciledTransaction[]>([]);
-  const [showOnlyUnmatched, setShowOnlyUnmatched] = useState(true);
+  const [filter, setFilter] = useState<'missingInApp' | 'missingInStatement' | 'matched' | 'all'>('missingInApp');
 
-  useEffect(() => {
-    if (!isOpen) return;
+  const { matched, missingInApp, missingInStatement } = useMemo(() => {
+    if (!isOpen) return { matched: [], missingInApp: [], missingInStatement: [] };
 
-    // Filter the application's cards based on the selected month and account
     const appTransactions = creditCards.filter(card => {
       const cardMonth = card.date.substring(0, 7);
       return cardMonth === reconMonth && card.paymentMethod === reconAccount;
     });
 
-    const cardAmounts = appTransactions.map(card => Math.abs(card.amount));
+    const matchedPairs: { statement: StatementTransaction; app: CreditCard }[] = [];
+    const notFoundInApp: StatementTransaction[] = [];
+    const notFoundInStatement = [...appTransactions];
 
-    // Determine the matched status for each parsed transaction
-    const results = parsedTransactions.map(statementTrans => {
-      const foundIndex = cardAmounts.findIndex(cardAmount => Math.abs(cardAmount - statementTrans.amount) < 0.01);
-      if (foundIndex > -1) {
-        // To handle duplicates, we remove the found amount from the list
-        cardAmounts.splice(foundIndex, 1);
-        return { ...statementTrans, isMatched: true };
+    for (const st of parsedTransactions) {
+      const appExpenseIndex = notFoundInStatement.findIndex(ae => {
+        const statementAmount = Math.abs(st.amount);
+        const appAmount = Math.abs(ae.amount);
+        const amountMatches = Math.abs(statementAmount - appAmount) < 0.01;
+        const descriptionMatches = ae.description.toLowerCase().includes(st.description.toLowerCase()) ||
+                                   st.description.toLowerCase().includes(ae.description.toLowerCase());
+        return amountMatches && descriptionMatches;
+      });
+
+      if (appExpenseIndex !== -1) {
+        const [appExpense] = notFoundInStatement.splice(appExpenseIndex, 1);
+        matchedPairs.push({ statement: st, app: appExpense });
+      } else {
+        notFoundInApp.push(st);
       }
-      return { ...statementTrans, isMatched: false };
-    });
+    }
 
-    setReconciledTransactions(results);
+    return { matched: matchedPairs, missingInApp: notFoundInApp, missingInStatement: notFoundInStatement };
   }, [isOpen, parsedTransactions, creditCards, reconMonth, reconAccount]);
 
-  // The transactions to be displayed in the table, based on the filter
-  const displayedTransactions = useMemo(() => {
-    if (showOnlyUnmatched) {
-      return reconciledTransactions.filter(t => !t.isMatched);
-    }
-    return reconciledTransactions;
-  }, [reconciledTransactions, showOnlyUnmatched]);
+  const handleAddClick = (transaction: StatementTransaction) => {
+    const [day, month, year] = transaction.date.split('/');
+    const formattedDate = `${year}-${month}-${day}`;
+
+    onAddExpense({
+      date: formattedDate,
+      description: transaction.description,
+      amount: transaction.amount,
+      paymentMethod: reconAccount,
+      category: 'Cartão de Crédito',
+    });
+  };
 
   if (!isOpen) {
     return null;
   }
 
+  const renderMissingInApp = () => (
+    <div>
+      <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2">
+        Lançamentos na Fatura, mas não no App ({missingInApp.length})
+      </h3>
+      <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+        Estes são os lançamentos que constam na fatura mas não foram encontrados no aplicativo.
+      </p>
+      <table className="w-full text-left text-sm">
+        {/* header */}
+        <tbody>
+          {missingInApp.map((t, i) => (
+            <tr key={`missing-app-${i}`} className="border-b dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50">
+              <td className="py-2 px-3">{t.date}</td>
+              <td className="py-2 px-3">{t.description}</td>
+              <td className="py-2 px-3 text-right font-mono">{t.amount.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}</td>
+              <td className="py-2 px-3 text-center">
+                <button onClick={() => handleAddClick(t)} className="text-blue-500 hover:text-blue-700 p-1">
+                  <PlusCircle className="w-5 h-5" />
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+
+  const renderMissingInStatement = () => (
+    <div>
+      <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-200 mt-6 mb-2">
+        Lançamentos no App, mas não na Fatura ({missingInStatement.length})
+      </h3>
+      <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+        Estes são os lançamentos registrados no aplicativo que não foram encontrados na fatura.
+      </p>
+      <table className="w-full text-left text-sm">
+        {/* header */}
+        <tbody>
+          {missingInStatement.map((e, i) => (
+            <tr key={`missing-stmt-${i}`} className="border-b dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50">
+              <td className="py-2 px-3">{format(new Date(e.date), 'dd/MM/yyyy', { locale: ptBR })}</td>
+              <td className="py-2 px-3">{e.description}</td>
+              <td className="py-2 px-3 text-right font-mono">{e.amount.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}</td>
+              <td className="py-2 px-3 text-center">
+                {onDeleteExpense && (
+                  <button onClick={() => onDeleteExpense(e.id)} className="text-red-500 hover:text-red-700 p-1">
+                    <Trash2 className="w-5 h-5" />
+                  </button>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-      <div className="bg-white dark:bg-gray-800 rounded-xl p-6 w-full max-w-5xl max-h-[90vh] flex flex-col">
-        <div className="flex-shrink-0 flex items-center justify-between mb-6">
-          <div>
-            <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Resultado da Conciliação</h2>
-            <p className="text-sm text-gray-500 dark:text-gray-400">Fatura de {reconMonth} para o cartão {reconAccount}</p>
-          </div>
-          <button
-            onClick={onClose}
-            className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-          >
-            <X className="w-5 h-5" />
-          </button>
+      <div className="bg-white dark:bg-gray-800 rounded-xl p-6 w-full max-w-6xl max-h-[90vh] flex flex-col">
+        <div className="flex-shrink-0 flex items-center justify-between mb-4">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Resultado da Conciliação</h2>
+          <button onClick={onClose} className="p-2 text-gray-400 hover:text-gray-600"><X className="w-5 h-5" /></button>
         </div>
 
-        <div className="flex-shrink-0 flex justify-end mb-4">
-          <button
-            onClick={() => setShowOnlyUnmatched(!showOnlyUnmatched)}
-            className="flex items-center gap-2 text-sm px-4 py-2 rounded-lg bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
-          >
-            {showOnlyUnmatched ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}
-            {showOnlyUnmatched ? 'Mostrar Todos os Itens' : 'Mostrar Apenas Não Encontrados'}
-          </button>
+        <div className="flex-shrink-0 flex items-center justify-between mb-4 p-4 bg-gray-50 dark:bg-gray-900/50 rounded-lg">
+           {/* Info Section */}
         </div>
 
-        <div className="flex-grow overflow-y-auto">
-          <div className="bg-gray-50 dark:bg-gray-900/50 rounded-lg border border-gray-200 dark:border-gray-700">
-            <table className="w-full text-sm">
-              <thead className="bg-gray-100 dark:bg-gray-800 sticky top-0">
-                <tr>
-                  <th className="text-left py-2 px-3 font-medium text-gray-600 dark:text-gray-300 w-24">Status</th>
-                  <th className="text-left py-2 px-3 font-medium text-gray-600 dark:text-gray-300">Data</th>
-                  <th className="text-left py-2 px-3 font-medium text-gray-600 dark:text-gray-300">Descrição</th>
-                  <th className="text-right py-2 px-3 font-medium text-gray-600 dark:text-gray-300">Valor</th>
-                  <th className="text-center py-2 px-3 font-medium text-gray-600 dark:text-gray-300 w-28">Ação</th>
-                </tr>
-              </thead>
-              <tbody>
-                {displayedTransactions.map((trans, index) => (
-                  <tr key={index} className="border-b border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800">
-                    <td className="py-2 px-3">
-                      {trans.isMatched ? (
-                        <span className="inline-flex items-center gap-1.5 px-2 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-300">
-                          <CheckCircle2 className="w-3.5 h-3.5" />
-                          Encontrado
-                        </span>
-                      ) : (
-                        <span className="inline-flex items-center gap-1.5 px-2 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800 dark:bg-red-900/20 dark:text-red-300">
-                          <AlertCircle className="w-3.5 h-3.5" />
-                          Não Encontrado
-                        </span>
-                      )}
-                    </td>
-                    <td className="py-2 px-3 text-gray-700 dark:text-gray-400">{trans.date}</td>
-                    <td className="py-2 px-3 text-gray-700 dark:text-gray-400">{trans.description}</td>
-                    <td className="py-2 px-3 font-mono text-right ${trans.isMatched ? 'text-gray-500' : 'text-red-600 dark:text-red-400 font-bold'}">
-                      {trans.amount.toFixed(2).replace('.', ',')}
-                    </td>
-                    <td className="py-2 px-3 text-center">
-                      {!trans.isMatched && (
-                        <button
-                          onClick={() => {
-                            const [day, month, year] = trans.date.split('/');
-                            const formattedDate = `${year}-${month}-${day}`;
-                            onAddExpense({
-                              date: formattedDate,
-                              description: trans.description,
-                              amount: trans.amount,
-                              paymentMethod: reconAccount,
-                            });
-                          }}
-                          className="bg-green-600 text-white px-2 py-1 rounded-md hover:bg-green-700 transition-colors text-xs flex items-center gap-1"
-                        >
-                          <Plus className="w-3 h-3" />
-                          Adicionar
-                        </button>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-            {displayedTransactions.length === 0 && (
-                <div className="text-center py-8 text-gray-500 dark:text-gray-400">
-                    {showOnlyUnmatched ? 'Nenhum item não encontrado.' : 'Nenhum item no extrato.'}
-                </div>
-            )}
-          </div>
+        <div className="flex-grow overflow-y-auto pr-2">
+          {missingInApp.length > 0 && renderMissingInApp()}
+          {missingInStatement.length > 0 && renderMissingInStatement()}
+
+          {missingInApp.length === 0 && missingInStatement.length === 0 && (
+            <div className="text-center py-8">
+              <CheckCircle className="w-12 h-12 text-green-500 mx-auto mb-4" />
+              <h3 className="text-lg font-semibold">Tudo conciliado!</h3>
+              <p className="text-gray-600 dark:text-gray-400">Nenhuma divergência encontrada.</p>
+            </div>
+          )}
+        </div>
+
+        <div className="flex-shrink-0 flex justify-end pt-6 mt-4 border-t dark:border-gray-700">
+          <button onClick={onClose} className="bg-gray-200 text-gray-800 px-6 py-2 rounded-lg hover:bg-gray-300">
+            Fechar
+          </button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
…tement

This commit enhances the credit card reconciliation feature.

Previously, the reconciliation process only identified transactions that were present on the credit card statement but were not recorded in the application.

This change introduces a two-way comparison:
1.  It continues to identify transactions on the statement but missing from the app (`missingInApp`).
2.  It now also identifies transactions recorded in the app but missing from the statement (`missingInStatement`).

The UI in `ReconciliationResults.tsx` has been updated to display both lists clearly, allowing users to either add missing transactions to the app or delete extraneous transactions from the app directly within the reconciliation view.