### PR TITLE
Refactor: Redesign reconciliation screen for improved legibility

### DIFF
--- a/client/src/components/ReconciliationResults.tsx
+++ b/client/src/components/ReconciliationResults.tsx
@@ -82,104 +82,106 @@ const ReconciliationResults: React.FC<ReconciliationResultsProps> = ({
   }
 
   const renderMissingInApp = () => (
-    <div>
+    <div className="bg-white dark:bg-gray-800 rounded-xl p-4 sm:p-6 border dark:border-gray-700">
       <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2">
         Lançamentos na Fatura, mas não no App ({missingInApp.length})
       </h3>
       <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
         Estes são os lançamentos que constam na fatura mas não foram encontrados no aplicativo.
       </p>
-      <table className="w-full text-left text-sm">
-        <thead className="bg-gray-50 dark:bg-gray-700/50">
-          <tr>
-            <th className="py-2 px-3 text-left font-semibold text-gray-600 dark:text-gray-300">Data</th>
-            <th className="py-2 px-3 text-left font-semibold text-gray-600 dark:text-gray-300">Descrição</th>
-            <th className="py-2 px-3 text-right font-semibold text-gray-600 dark:text-gray-300">Valor</th>
-            <th className="py-2 px-3 text-center font-semibold text-gray-600 dark:text-gray-300">Ações</th>
-          </tr>
-        </thead>
-        <tbody>
-          {missingInApp.map((t, i) => (
-            <tr key={`missing-app-${i}`} className="border-b dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50">
-              <td className="py-2 px-3">{t.date}</td>
-              <td className="py-2 px-3">{t.description}</td>
-              <td className="py-2 px-3 text-right font-mono">{t.amount.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}</td>
-              <td className="py-2 px-3 text-center">
-                <button onClick={() => handleAddClick(t)} className="text-blue-500 hover:text-blue-700 p-1">
-                  <PlusCircle className="w-5 h-5" />
-                </button>
-              </td>
+      <div className="overflow-x-auto -mx-4 sm:-mx-6">
+        <table className="min-w-full text-left text-sm">
+          <thead className="bg-gray-50 dark:bg-gray-700/50">
+            <tr>
+              <th className="py-2 px-4 sm:px-6 text-left font-semibold text-gray-600 dark:text-gray-300">Data</th>
+              <th className="py-2 px-4 sm:px-6 text-left font-semibold text-gray-600 dark:text-gray-300">Descrição</th>
+              <th className="py-2 px-4 sm:px-6 text-right font-semibold text-gray-600 dark:text-gray-300">Valor</th>
+              <th className="py-2 px-4 sm:px-6 text-center font-semibold text-gray-600 dark:text-gray-300">Ações</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {missingInApp.map((t, i) => (
+              <tr key={`missing-app-${i}`} className="border-b dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/40">
+                <td className="py-2 px-4 sm:px-6 whitespace-nowrap">{t.date}</td>
+                <td className="py-2 px-4 sm:px-6">{t.description}</td>
+                <td className="py-2 px-4 sm:px-6 text-right font-mono whitespace-nowrap">{t.amount.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}</td>
+                <td className="py-2 px-4 sm:px-6 text-center">
+                  <button onClick={() => handleAddClick(t)} className="text-blue-500 hover:text-blue-700 p-1">
+                    <PlusCircle className="w-5 h-5" />
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 
   const renderMissingInStatement = () => (
-    <div>
-      <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-200 mt-6 mb-2">
+    <div className="bg-white dark:bg-gray-800 rounded-xl p-4 sm:p-6 border dark:border-gray-700">
+      <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-2">
         Lançamentos no App, mas não na Fatura ({missingInStatement.length})
       </h3>
       <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
         Estes são os lançamentos registrados no aplicativo que não foram encontrados na fatura.
       </p>
-      <table className="w-full text-left text-sm">
-        <thead className="bg-gray-50 dark:bg-gray-700/50">
-          <tr>
-            <th className="py-2 px-3 text-left font-semibold text-gray-600 dark:text-gray-300">Data</th>
-            <th className="py-2 px-3 text-left font-semibold text-gray-600 dark:text-gray-300">Descrição</th>
-            <th className="py-2 px-3 text-right font-semibold text-gray-600 dark:text-gray-300">Valor</th>
-            <th className="py-2 px-3 text-center font-semibold text-gray-600 dark:text-gray-300">Ações</th>
-          </tr>
-        </thead>
-        <tbody>
-          {missingInStatement.map((e, i) => (
-            <tr key={`missing-stmt-${i}`} className="border-b dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50">
-              <td className="py-2 px-3">{format(new Date(e.date), 'dd/MM/yyyy', { locale: ptBR })}</td>
-              <td className="py-2 px-3">{e.description}</td>
-              <td className="py-2 px-3 text-right font-mono">{e.amount.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}</td>
-              <td className="py-2 px-3 text-center">
-                {onDeleteExpense && (
-                  <button onClick={() => onDeleteExpense(e.id)} className="text-red-500 hover:text-red-700 p-1">
-                    <Trash2 className="w-5 h-5" />
-                  </button>
-                )}
-              </td>
+      <div className="overflow-x-auto -mx-4 sm:-mx-6">
+        <table className="min-w-full text-left text-sm">
+          <thead className="bg-gray-50 dark:bg-gray-700/50">
+            <tr>
+              <th className="py-2 px-4 sm:px-6 text-left font-semibold text-gray-600 dark:text-gray-300">Data</th>
+              <th className="py-2 px-4 sm:px-6 text-left font-semibold text-gray-600 dark:text-gray-300">Descrição</th>
+              <th className="py-2 px-4 sm:px-6 text-right font-semibold text-gray-600 dark:text-gray-300">Valor</th>
+              <th className="py-2 px-4 sm:px-6 text-center font-semibold text-gray-600 dark:text-gray-300">Ações</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {missingInStatement.map((e, i) => (
+              <tr key={`missing-stmt-${i}`} className="border-b dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/40">
+                <td className="py-2 px-4 sm:px-6 whitespace-nowrap">{format(new Date(e.date), 'dd/MM/yyyy', { locale: ptBR })}</td>
+                <td className="py-2 px-4 sm:px-6">{e.description}</td>
+                <td className="py-2 px-4 sm:px-6 text-right font-mono whitespace-nowrap">{e.amount.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}</td>
+                <td className="py-2 px-4 sm:px-6 text-center">
+                  {onDeleteExpense && (
+                    <button onClick={() => onDeleteExpense(e.id)} className="text-red-500 hover:text-red-700 p-1">
+                      <Trash2 className="w-5 h-5" />
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-      <div className="bg-white dark:bg-gray-800 rounded-xl p-6 w-full max-w-6xl max-h-[90vh] flex flex-col">
-        <div className="flex-shrink-0 flex items-center justify-between mb-4">
+    <div className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center p-4 z-50">
+      <div className="bg-gray-50 dark:bg-gray-900 rounded-xl w-full max-w-6xl max-h-[90vh] flex flex-col">
+        <div className="flex-shrink-0 flex items-center justify-between p-4 sm:p-6 border-b dark:border-gray-700">
           <h2 className="text-xl font-semibold text-gray-900 dark:text-white">Resultado da Conciliação</h2>
-          <button onClick={onClose} className="p-2 text-gray-400 hover:text-gray-600"><X className="w-5 h-5" /></button>
+          <button onClick={onClose} className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-white rounded-full"><X className="w-5 h-5" /></button>
         </div>
 
-        <div className="flex-shrink-0 flex items-center justify-between mb-4 p-4 bg-gray-50 dark:bg-white/5 rounded-lg border border-gray-200 dark:border-gray-700">
-           {/* Info Section */}
-        </div>
+        <div className="flex-grow overflow-y-auto p-4 sm:p-6 space-y-6">
+          { /* Info Section - Removida para simplificar o layout */ }
 
-        <div className="flex-grow overflow-y-auto pr-2">
           {missingInApp.length > 0 && renderMissingInApp()}
           {missingInStatement.length > 0 && renderMissingInStatement()}
 
           {missingInApp.length === 0 && missingInStatement.length === 0 && (
-            <div className="text-center py-8">
+            <div className="text-center py-8 bg-white dark:bg-gray-800 rounded-lg border dark:border-gray-700">
               <CheckCircle className="w-12 h-12 text-green-500 mx-auto mb-4" />
-              <h3 className="text-lg font-semibold">Tudo conciliado!</h3>
+              <h3 className="text-lg font-semibold dark:text-white">Tudo conciliado!</h3>
               <p className="text-gray-600 dark:text-gray-400">Nenhuma divergência encontrada.</p>
             </div>
           )}
         </div>
 
-        <div className="flex-shrink-0 flex justify-end pt-6 mt-4 border-t dark:border-gray-700">
-          <button onClick={onClose} className="bg-gray-200 text-gray-800 px-6 py-2 rounded-lg hover:bg-gray-300">
+        <div className="flex-shrink-0 flex justify-end p-4 sm:p-6 border-t dark:border-gray-700">
+          <button onClick={onClose} className="bg-gray-200 text-gray-800 px-6 py-2 rounded-lg hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600">
             Fechar
           </button>
         </div>


### PR DESCRIPTION
The reconciliation screen suffered from poor legibility in dark mode due to low contrast between the text and background. This commit completely refactors the component to address this issue.

The main changes include:
- Adjusting the modal background to a darker shade (`dark:bg-gray-900`).
- Placing each table within its own "card" with a lighter background (`dark:bg-gray-800`) and a border, creating a clear visual hierarchy.
- Removing the now-redundant info section to simplify the layout.
- Improving padding and spacing for a cleaner, more organized presentation.

These changes ensure that the reconciliation screen is now highly readable and visually consistent with the rest of the application's design system.