### PR TITLE
Fix: Cycle through colors for Top 10 Categories

### DIFF
--- a/client/src/components/Dashboard.tsx
+++ b/client/src/components/Dashboard.tsx
@@ -563,7 +563,7 @@ const Dashboard: React.FC = () => {
                   {intelligentAnalysis.topCategories.map(([category, amount], index) => (
                     <div key={category} className="flex items-center justify-between py-2">
                       <div className="flex items-center min-w-0 flex-1 mr-4">
-                        <div className={`w-8 h-8 rounded-full bg-blue-${(index + 1) * 100} flex items-center justify-center text-white text-sm font-bold mr-3 flex-shrink-0`}>
+                        <div className={`w-8 h-8 rounded-full bg-blue-${((index % 9) + 1) * 100} flex items-center justify-center text-white text-sm font-bold mr-3 flex-shrink-0`}>
                           {index + 1}
                         </div>
                         <span className="text-gray-900 dark:text-white text-sm truncate" title={category}>


### PR DESCRIPTION
This commit fixes a styling issue in the "Top 10 Categorias do Mês" card where the 10th item's number did not have a background color. The logic has been updated to cycle through the available blue color shades, ensuring all numbers are styled consistently.